### PR TITLE
[codeowners] update codeowners to reference groups instead of users

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-/.github/CODEOWNERS                                    @BugRoger @databus23 @dhoeller @edda @geisslet @artherd42 @martinpink @rhalina @mutax
-*                                                      @sebageek @sven-rosenzweig @rhalina @mutax @joker-at-work
+* @sapcc/network-api-contributors @sapcc/cc_github_managers_approval
+/.github/CODEOWNERS @sapcc/cc_github_managers_approval


### PR DESCRIPTION
Based on our engineering policy and PCI DSS 4.0 requirements, all repositories that modify production infrastructure must enforce a two-person approval process.

This patch updates the CODEOWNERS file to use the appropriate groups instead of listing individual users, now that these groups are properly defined.